### PR TITLE
Añadir rate limiting a los endpoints

### DIFF
--- a/api/middlewares/rateLimit.js
+++ b/api/middlewares/rateLimit.js
@@ -1,0 +1,17 @@
+import ratelimit from 'koa-ratelimit';
+
+export const cheapLimit = ratelimit({
+  driver: 'memory',
+  db: new Map(),
+  duration: 60_000,
+  max: 300,
+  id: (ctx) => ctx.ip,
+});
+
+export const expensiveLimit = ratelimit({
+  driver: 'memory',
+  db: new Map(),
+  duration: 60_000,
+  max: 20,
+  id: (ctx) => ctx.ip,
+});

--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,7 @@
     "koa": "^2.16.4",
     "koa-bodyparser": "^4.4.1",
     "koa-passport": "^6.0.0",
+    "koa-ratelimit": "^6.0.0",
     "koa-router": "^14.0.0",
     "moment": "^2.30.1",
     "objection": "^3.1.5",

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -2,13 +2,17 @@ import Router from '@koa/router';
 import googleRoutes from './google.js';
 import appointmentsRoutes from './appointments.js';
 import authRoutes from './auth.js';
+import { cheapLimit, expensiveLimit } from '../middlewares/rateLimit.js';
 
 const router = new Router({
   prefix: '/api',
 });
 
-router.use(googleRoutes.routes());
-router.use(authRoutes.routes());
-router.use(appointmentsRoutes.routes());
+// Public routes
+router.use(cheapLimit, appointmentsRoutes.routes());
+router.use(cheapLimit, authRoutes.routes());
+
+// Partly public (callback)
+router.use(expensiveLimit, googleRoutes.routes());
 
 export default router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "koa": "^2.16.4",
         "koa-bodyparser": "^4.4.1",
         "koa-passport": "^6.0.0",
+        "koa-ratelimit": "^6.0.0",
         "koa-router": "^14.0.0",
         "moment": "^2.30.1",
         "objection": "^3.1.5",
@@ -1264,6 +1265,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/async-ratelimiter": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/async-ratelimiter/-/async-ratelimiter-1.6.5.tgz",
+      "integrity": "sha512-S7q3lpWZyo3E7VBIsOcASeKXlG86r+PtiwYViimDZ7AcHg+yDjMskDMRtVtzcPEDFEyBSs8EzJTy3JDl/KDdGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/asynckit": {
@@ -3169,6 +3179,19 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/koa-ratelimit": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/koa-ratelimit/-/koa-ratelimit-6.0.0.tgz",
+      "integrity": "sha512-UH1CXCF+yVhx5r5Fvx5eOKhc8sMHU/HhGBNCOaJ/SLO0+IcB6g5aKIE63eWsq7L3niwQWLfEbDtNGU3epKt0Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "async-ratelimiter": "^1.5.2",
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/koa-router": {


### PR DESCRIPTION
- Closes #30

Añadi 2 limites diferentes para distintas rutas. Uno para las rutas que no consumen nada de la API de google, este es mas permisivo ya que esas requests son practicamente gratuitas. Otro para las calls a Google Calendar API porque si nos pasamos del limite empieza a cobrar.